### PR TITLE
Change: remove ord() call

### DIFF
--- a/duck2spark/duck2spark.py
+++ b/duck2spark/duck2spark.py
@@ -62,8 +62,8 @@ void loop()
 	# payload into FLASH memory of digispark
 	declare = "#define DUCK_LEN " + str(l) + "\nconst PROGMEM uint8_t duckraw [DUCK_LEN] = {\n\t"
 	for c in range(l - 1):
-		declare += str(hex(ord(payload[c]))) + ", "
-	declare += str(hex(ord(payload[l - 1]))) + "\n};\nint i = %d; //how many times the payload should run (-1 for endless loop)\n" % loop_count
+		declare += str(hex(payload[c])) + ", "
+	declare += str(hex(payload[l - 1])) + "\n};\nint i = %d; //how many times the payload should run (-1 for endless loop)\n" % loop_count
 	if blink:
 		declare += "bool blink=true;\n"
 	else:


### PR DESCRIPTION
- Error displayed when running with payload .bin:

> This happens because of python version conflicts, `ord()` call is redundant in this case

```
hubber@Hubber MINGW64 ~/Desktop/Prokject/Get-Chrome80Dump (main)
$ python duck2spark/duck2spark.py -i Chrome80DuckPayload.bin -l 1 -f 2000 -o Chrome80DuckPayload.ino
Traceback (most recent call last):
  File "C:\Users\hubber\Desktop\Prokject\Get-Chrome80Dump\duck2spark\duck2spark.py", line 155, in <module>
    main(sys.argv[1:])
  File "C:\Users\hubber\Desktop\Prokject\Get-Chrome80Dump\duck2spark\duck2spark.py", line 140, in main
    result = generate_source(payload, init_delay=init_delay, loop_count=loop_count, loop_delay=loop_delay, blink=blink)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hubber\Desktop\Prokject\Get-Chrome80Dump\duck2spark\duck2spark.py", line 65, in generate_source
    declare += str(hex(ord(payload[c]))) + ", "
                       ^^^^^^^^^^^^^^^
TypeError: ord() expected string of length 1, but int found
```

- Corrected code snippet - `Lines 65, 66`

```
declare += str(hex(payload[c])) + ", "
declare += str(hex(payload[l - 1])) + "\n};\nint i = %d; //how many times the payload should run (-1 for endless loop)\n" % loop_count
```